### PR TITLE
Add 2ms delay after creating script before executing it

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,11 +77,14 @@ def execute():
         returncode = proc.returncode
         stdout = proc.stdout.read(MAX_DATA_SIZE).decode()
         stderr = proc.stderr.read(MAX_DATA_SIZE).decode()
+        if returncode != 0:
+            app.logger.error(stderr)
         return success(returncode, stdout, stderr, "")
     except OSError as err:
-        app.logger.error(err);
+        app.logger.error(err)
         return success(126, "", "", "Execution fail")
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as err:
+        app.logger.error(err)
         return success(111, "", "", "Execution time limit exceeded")
 
 # Run the app

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import subprocess
 import base64
 import logging
 import secrets
+import time
 
 # Set up logging
 logging.basicConfig(level=logging.DEBUG)
@@ -65,6 +66,8 @@ def execute():
         env = os.environ.copy()
         for key, value in request_json.get("env", {}).items():
             env[key] = value
+
+        time.sleep(0.002)
 
         proc = subprocess.Popen(
             [path] + shlex.split(request_json["calldata"]),


### PR DESCRIPTION
This solves an issue with some exit code 126s due to a `Text file busy` error. Also includes some more verbose error logging.